### PR TITLE
setNamespace() is not mandatory in the Cache interface

### DIFF
--- a/src/Provider/DoctrineCacheServiceProvider.php
+++ b/src/Provider/DoctrineCacheServiceProvider.php
@@ -54,7 +54,9 @@ class DoctrineCacheServiceProvider implements ServiceProviderInterface
             foreach ($app['caches.options'] as $name => $options) {
                 $container[$name] = function () use ($app, $options) {
                     $cache = $app['cache_factory']($options['driver'], $options);
-                    $cache->setNamespace($options['namespace']);
+                    if (isset($options['namespace'])) {
+                        $cache->setNamespace($options['namespace']);
+                    }
 
                     return $cache;
                 };


### PR DESCRIPTION
Provider should allow cache without namespace